### PR TITLE
Enable automatic CPU thread detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Work for Ethereum
 
 ```
 
-You need to add `-t numberThreads` to get better speed
+Keyhunt now detects the number of available CPU cores and uses them all by
+default. You can still add `-t numberThreads` to override this value.
 
 - Run against Puzzle 125 (bsgs mode)
 
@@ -30,7 +31,8 @@ You need to add `-t numberThreads` to get better speed
 ./keyhunt -m bsgs -f tests/125.txt -b 125 -q -s 10 -R
 ```
 
-You need to add `-t numberThreads` and `-k factor` to get better speed
+By default all CPU threads are used. You can combine `-t numberThreads` with
+`-k factor` to increase memory usage and improve speed.
 
 ## Free Code
 

--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -471,10 +471,24 @@ int main(int argc, char **argv)	{
 
 	secp = new Secp256K1();
 	secp->Init();
-	OUTPUTSECONDS.SetInt32(30);
-	ZERO.SetInt32(0);
-	ONE.SetInt32(1);
-	BSGS_GROUP_SIZE.SetInt32(CPU_GRP_SIZE);
+        OUTPUTSECONDS.SetInt32(30);
+        ZERO.SetInt32(0);
+        ONE.SetInt32(1);
+        BSGS_GROUP_SIZE.SetInt32(CPU_GRP_SIZE);
+
+#ifdef _OPENMP
+        NTHREADS = omp_get_num_procs();
+        omp_set_num_threads(NTHREADS);
+#else
+#if defined(_WIN64) && !defined(__CYGWIN__)
+        SYSTEM_INFO sysinfo;
+        GetSystemInfo(&sysinfo);
+        NTHREADS = sysinfo.dwNumberOfProcessors;
+#else
+        NTHREADS = sysconf(_SC_NPROCESSORS_ONLN);
+#endif
+#endif
+        printf("[+] Default threads : %u\n", NTHREADS);
 	
 #if defined(_WIN64) && !defined(__CYGWIN__)
 	//Any windows secure random source goes here


### PR DESCRIPTION
## Summary
- autodetect number of processors at startup and use all for Keyhunt
- mention new default thread detection in README

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6851ca850cfc83229ee13d52f0ab3533