### PR TITLE
Minor fixes for gtable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ All the vanity address and his privatekeys will be saved in the file `VANITYKEYF
 rmd stands for RIPE Message Digest (see https://en.wikipedia.org/wiki/RIPEMD )
 
 mode rmd160 work in the same way than address, but the diference is that file need to have hash rmd160 instead of addresses.
+When using the optimized `rmd160-bsgs` mode the same bloom filter loaded here is checked before each hash comparison to speed up the search.
 
 
 example file `tests/1to32.rmd` :

--- a/keyhunt.cpp
+++ b/keyhunt.cpp
@@ -23,13 +23,36 @@ email: albertobsd@gmail.com
 #include "secp256k1/Int.h"
 #include "secp256k1/IntGroup.h"
 #include "secp256k1/Random.h"
+extern Secp256K1 *secp;
 
 #include "hash/sha256.h"
+#include "xxhash/xxhash.h"
 
 #include <fstream>
-#include <secp256k1/SECP256K1.h>
+
 Point* GTable = nullptr;
 int GTableSize = 0;
+
+static Point DecompressPoint(const uint8_t buf[33]) {
+    Point P;
+    Int x;
+    for (int i = 0; i < 32; ++i) {
+        x.SetByte(31 - i, buf[i + 1]);
+    }
+    Int t, y;
+    t.ModSquareK1(&x);
+    y.ModMulK1(&t, &x);
+    y.ModAdd(7);
+    y.ModSqrt();
+    bool even = buf[0] == 0x02;
+    if ((!y.IsEven() && even) || (y.IsEven() && !even)) {
+        y.ModNeg();
+    }
+    P.x.Set(&x);
+    P.y.Set(&y);
+    P.z.SetInt32(1);
+    return P;
+}
 
 void generate_gtable(int bits, const char* filename) {
     printf("[+] Generating GTable 2^%d...\n", bits);
@@ -38,13 +61,13 @@ void generate_gtable(int bits, const char* filename) {
         perror("[-] Cannot create GTable file");
         exit(1);
     }
-    Point G = Point::G();
+    Point G = secp->G;
     Point P = G;
     for (int64_t i = 0; i < (1LL << bits); ++i) {
-        uint8_t compressed[33];
-        P.getPublicKeyCompressed(compressed);
+        unsigned char compressed[33];
+        secp->GetPublicKeyRaw(true, P, (char*)compressed);
         fwrite(compressed, 1, 33, f);
-        P = P + G;
+        P = secp->AddDirect(P, G);
     }
     fclose(f);
     printf("[+] GTable generated and saved to %s\n", filename);
@@ -66,7 +89,7 @@ void load_gtable(const char* filename, int bits) {
     uint8_t buffer[33];
     for (int i = 0; i < GTableSize; ++i) {
         fread(buffer, 1, 33, f);
-        GTable[i].fromBytesCompressed(buffer);
+        GTable[i] = DecompressPoint(buffer);
     }
     fclose(f);
     printf("[+] GTable loaded (%d entries)\n", GTableSize);
@@ -74,9 +97,14 @@ void load_gtable(const char* filename, int bits) {
 
 Point ComputePublicKey_GTable(const Int& priv) {
     Point result;
+    result.Clear();
+    Int tmp((Int*)&priv);
     for (int i = 0; i < GTableSize; ++i) {
-        if (priv.testBit(i)) {
-            result = result + GTable[i];
+        if (tmp.GetBit(i)) {
+            if (result.isZero())
+                result = GTable[i];
+            else
+                result = secp->AddDirect(result, GTable[i]);
         }
     }
     return result;
@@ -142,8 +170,6 @@ struct rmd160_entry {
         uint8_t hash[20];
         uint8_t priv[32];
 };
-
-
 struct tothread {
 	int nt;     //Number thread
 	char *rs;   //range start
@@ -406,6 +432,24 @@ char buffer_bloom_file[1024];
 struct bsgs_xvalue *bPtable;
 struct address_value *addressTable;
 
+static const uint32_t HASH_BITS = 18;
+static std::vector<std::vector<uint32_t>> rmd160_ht(1u << HASH_BITS);
+
+static inline void rmd160_ht_add(uint32_t idx) {
+    uint64_t h = XXH3_64bits(addressTable[idx].value, 20);
+    rmd160_ht[h & ((1u << HASH_BITS) - 1)].push_back(idx);
+}
+
+static int rmd160_ht_lookup(const uint8_t *data) {
+    uint64_t h = XXH3_64bits(data, 20);
+    auto &b = rmd160_ht[h & ((1u << HASH_BITS) - 1)];
+    for (uint32_t i : b) {
+        if (memcmp(addressTable[i].value, data, 20) == 0)
+            return 1;
+    }
+    return 0;
+}
+
 struct oldbloom oldbloom_bP;
 
 struct bloom *bloom_bP;
@@ -487,7 +531,7 @@ Int lambda,lambda2,beta,beta2;
 Secp256K1 *secp;
 
 
-int gtable_bits = -1; // -1 = desativado, 0 = 2^20, ..., 6 = 2^26
+int gtable_bits = -1; // -1 disabled, otherwise table bits (20 + gtable_bits up to 60)
 char gtable_filename[64] = {0};
 int main(int argc, char **argv)	{
 	char buffer[2048];
@@ -859,6 +903,15 @@ int main(int argc, char **argv)	{
 					exit(EXIT_FAILURE);
 				}
 			break;
+                        case 'g':
+                                gtable_bits = atoi(optarg);
+                                if (gtable_bits < 0 || gtable_bits > 60) {
+                                        printf("[-] Invalid GTable bits (range 0-60 allowed)\n");
+                                        exit(1);
+                                }
+                                sprintf(gtable_filename, "gtable_%d.bin", gtable_bits + 20);
+                                load_gtable(gtable_filename, gtable_bits + 20);
+                        break;
 			case 'z':
 				FLAGBLOOMMULTIPLIER= strtol(optarg,NULL,10);
 				if(FLAGBLOOMMULTIPLIER <= 0)	{
@@ -1050,10 +1103,12 @@ int main(int argc, char **argv)	{
 		
 		if(FLAGMODE != MODE_VANITY && !FLAGREADEDFILE1)	{
 			printf("[+] Sorting data ...");
-			_sort(addressTable,N);
-			printf(" done! %" PRIu64 " values were loaded and sorted\n",N);
-			writeFileIfNeeded(fileName);
-		}
+                        _sort(addressTable,N);
+                        printf(" done! %" PRIu64 " values were loaded and sorted\n",N);
+                        writeFileIfNeeded(fileName);
+                        for(uint32_t j = 0; j < N; ++j)
+                                rmd160_ht_add(j);
+                }
 	}
 	
 	if(FLAGMODE == MODE_BSGS )	{
@@ -6468,8 +6523,10 @@ bool forceReadFileAddress(char *fileName)	{
 			numberItems--;
 		}
 	}
-	N = numberItems;
-	return true;
+        N = numberItems;
+        for(uint32_t j = 0; j < N; ++j)
+                rmd160_ht_add(j);
+        return true;
 }
 
 bool forceReadFileAddressEth(char *fileName)	{
@@ -6546,8 +6603,10 @@ bool forceReadFileAddressEth(char *fileName)	{
 		}
 	}
 	
-	fclose(fileDescriptor);
-	return true;
+        fclose(fileDescriptor);
+        for(uint32_t j = 0; j < N; ++j)
+                rmd160_ht_add(j);
+        return true;
 }
 
 
@@ -6771,8 +6830,10 @@ void writeFileIfNeeded(const char *fileName)	{
 			}
 			printf(".");
 			
-			FLAGREADEDFILE1 = 1;	
-			fclose(fileDescriptor);		
+                        FLAGREADEDFILE1 = 1;
+                        for(uint32_t j = 0; j < N; ++j)
+                                rmd160_ht_add(j);
+                        fclose(fileDescriptor);
 			printf("\n");
 		}
 	}
@@ -6794,11 +6855,15 @@ void generate_block(Int *start,uint64_t count,struct rmd160_entry *table){
         Point pub = secp->ComputePublicKey(&key);
 
         uint64_t i = 0;
-        while(i + 4 <= count){
+        while(i + 8 <= count){
                 Point p0 = pub;
                 Point p1 = secp->AddDirect(p0,secp->G);
                 Point p2 = secp->AddDirect(p1,secp->G);
                 Point p3 = secp->AddDirect(p2,secp->G);
+                Point p4 = secp->AddDirect(p3,secp->G);
+                Point p5 = secp->AddDirect(p4,secp->G);
+                Point p6 = secp->AddDirect(p5,secp->G);
+                Point p7 = secp->AddDirect(p6,secp->G);
 
                 secp->GetHash160(P2PKH,true,
                         p0,p1,p2,p3,
@@ -6806,14 +6871,24 @@ void generate_block(Int *start,uint64_t count,struct rmd160_entry *table){
                         table[i+1].hash,
                         table[i+2].hash,
                         table[i+3].hash);
+                secp->GetHash160(P2PKH,true,
+                        p4,p5,p6,p7,
+                        table[i+4].hash,
+                        table[i+5].hash,
+                        table[i+6].hash,
+                        table[i+7].hash);
 
                 key.Get32Bytes(table[i].priv); key.AddOne();
                 key.Get32Bytes(table[i+1].priv); key.AddOne();
                 key.Get32Bytes(table[i+2].priv); key.AddOne();
                 key.Get32Bytes(table[i+3].priv); key.AddOne();
+                key.Get32Bytes(table[i+4].priv); key.AddOne();
+                key.Get32Bytes(table[i+5].priv); key.AddOne();
+                key.Get32Bytes(table[i+6].priv); key.AddOne();
+                key.Get32Bytes(table[i+7].priv); key.AddOne();
 
-                pub = secp->AddDirect(p3,secp->G);
-                i += 4;
+                pub = secp->AddDirect(p7,secp->G);
+                i += 8;
         }
 
         for(; i < count; i++){
@@ -6830,7 +6905,7 @@ void compare_block(struct rmd160_entry *table,uint64_t count){
 #pragma omp parallel for schedule(static)
                 for(uint64_t i = 0; i < count; i++){
                         if(bloom_check(&bloom,table[i].hash,20)){
-                                if(searchbinary(addressTable,(char*)table[i].hash,N)){
+                                if(rmd160_ht_lookup(table[i].hash)){
                                         Int key;
                                         key.Set32Bytes(table[i].priv);
                                         rmd160toaddress_dst((char*)table[i].hash,address);
@@ -6846,7 +6921,7 @@ void compare_block(struct rmd160_entry *table,uint64_t count){
         }else{
                 for(uint64_t i = 0; i < count; i++){
                         if(bloom_check(&bloom,table[i].hash,20)){
-                                if(searchbinary(addressTable,(char*)table[i].hash,N)){
+                                if(rmd160_ht_lookup(table[i].hash)){
                                         Int key;
                                         key.Set32Bytes(table[i].priv);
                                         rmd160toaddress_dst((char*)table[i].hash,address);
@@ -6904,13 +6979,4 @@ void *thread_process_rmd160_bsgs(void *vargp) {
         free(table);
         ends[thread_number] = 1;
         return NULL;
-
-		case 'g':
-			gtable_bits = atoi(optarg);
-			if (gtable_bits < 0 || gtable_bits > 6) {
-				printf("[-] Invalid GTable bits (range 0–6 allowed)\n");
-				exit(1);
-			}
-			sprintf(gtable_filename, "gtable_%d.bin", gtable_bits + 20);
-			break;
 }


### PR DESCRIPTION
## Summary
- fix include path for secp256k1 header
- allow larger `-g` values and load GTables on demand
- remove duplicate include
- add helper to decompress and persist GTables
- add xxhash-based lookup table and process 8 hashes per block
- note bloom filter use in README

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685464376e7c8322965c2e0d8495a798